### PR TITLE
Docs, a test, and additional API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,10 @@
+name: Test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: swift test

--- a/Sources/TaskQueue/TaskQueue.swift
+++ b/Sources/TaskQueue/TaskQueue.swift
@@ -1,15 +1,20 @@
+/// A queue that executes queued tasks serially, in the order they are queued.
 public final actor TaskQueue {
     private var task = Task<Void, Never> { }
 
+    /// Creates a new task group.
     public init() {}
     
+    /// Queue the given `work` in the task queue, waiting for any previously queued units of work to finish before executing the `work.`
+    ///
+    /// - Returns: The task representing the asynchronous `work`. The execution of `work` can be prevented by cancelling the returned task before the `work` is executed.
     @discardableResult
-    public func queueAction<T>(_ perform: @Sendable @escaping () async throws -> T) -> Task<T, Error> {
+    public func queueThrowingAction<T>(_ work: @Sendable @escaping () async throws -> T) -> Task<T, Error> {
         let currentTask = self.task
         let newTask = Task<T, Error> {
             await currentTask.value
             try Task.checkCancellation()
-            return try await perform()
+            return try await work()
         }
         
         self.task = Task {
@@ -17,5 +22,37 @@ public final actor TaskQueue {
         }
         
         return newTask
+    }
+    
+    /// Queue the given `work` in the task queue, waiting for any previously queued units of work to finish before executing the `work.`
+    ///
+    /// - Returns: The task representing the asynchronous `work`.
+    @discardableResult
+    public func queueAction<T>(_ work: @Sendable @escaping () async -> T) -> Task<T, Never> {
+        let currentTask = self.task
+        let newTask = Task<T, Never> {
+            await currentTask.value
+            return await work()
+        }
+        
+        self.task = Task {
+            _ = await newTask.value
+        }
+        
+        return newTask
+    }
+    
+    /// Run the given `work` in the task queue, waiting for any previously queued units of work to finish before executing the `work.`
+    ///
+    /// - Returns: The return value of `work`.
+    public func run<T>(_ work: @Sendable @escaping () async -> T) async -> T {
+        await queueAction(work).value
+    }
+    
+    /// Run the given `work` in the task queue, waiting for any previously queued units of work to finish before executing the `work.`
+    /// 
+    /// - Returns: The return value of `work`.
+    public func runThrowing<T>(_ work: @Sendable @escaping () async throws -> T) async throws -> T {
+        try await queueThrowingAction(work).value
     }
 }

--- a/Tests/TaskQueueTests/TaskQueueTests.swift
+++ b/Tests/TaskQueueTests/TaskQueueTests.swift
@@ -2,10 +2,24 @@ import XCTest
 @testable import TaskQueue
 
 final class TaskQueueTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(TaskQueue().text, "Hello, World!")
+    func testTaskExecutionOrder() async {
+        let queue = TaskQueue()
+        
+        let expectations = (1...10).map { _ -> XCTestExpectation in
+            let expectation = XCTestExpectation()
+            expectation.assertForOverFulfill = true
+            return expectation
+        }
+        
+        // This test works by having the first-queued tasks wait the longest, thereby testing execution order.
+        for index in 1...10 {
+            await queue.queueThrowingAction {
+                let waitInterval = 1_000_000_000 / UInt64(index)
+                try await Task.sleep(nanoseconds: waitInterval)
+                expectations[index - 1].fulfill()
+            }
+        }
+        
+        wait(for: expectations, timeout: 10, enforceOrder: true)
     }
 }


### PR DESCRIPTION
- Added docs to `TaskQueue`
- Added `run` in addition to `queue`, which returns the result of the queued work instead of a task, for when task-level control isn't required
- Added separate throwing and non-throwing methods (non-throwing methods don't support cancellation)
- Added a test that validates task execution order
- Configured a Github workflow that runs `swift test` on push